### PR TITLE
Upgrade to Grafana v5.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN     git clone https://github.com/etsy/statsd.git /src/statsd                
 # Install Grafana
 RUN     mkdir /src/grafana                                                                                    &&\
         mkdir /opt/grafana                                                                                    &&\
-        wget https://grafanarel.s3.amazonaws.com/builds/grafana-4.1.1-1484211277.linux-x64.tar.gz -O /src/grafana/grafana.tar.gz &&\
+        wget https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-5.1.3.linux-x64.tar.gz -O /src/grafana/grafana.tar.gz &&\
         tar -xzf /src/grafana/grafana.tar.gz -C /opt/grafana --strip-components=1                             &&\
         rm /src/grafana/grafana.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-StatsD + Graphite + Grafana 4.1
+StatsD + Graphite + Grafana 5.1
 -------------------------------
 
 This image contains a sensible default configuration of StatsD, Graphite and Grafana. This image is used as a base for [dokku](https://github.com/progrium/dokku) graphite-statsd plugin.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2'
 services:
   grafana_graphite:
     build: .
-    image: kamon/grafana_graphite
     container_name: kamon-grafana-dashboard
     ports:
       - '80:80'


### PR DESCRIPTION
[5.1 release notes](https://community.grafana.com/t/release-notes-v-5-1-x/6958)
[4.2 - current release notes](https://community.grafana.com/c/releases)