### PR TITLE
Bump Grafana to 11.6.0 and Graphite to 1.1.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
 
   markdown-lint:
     name: markdown-lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   yamllint:
     name: yamllint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN npm install --global statsd@0.9.0
 # See https://github.com/graphite-project/graphite-web/blob/1.1.x/docs/install-pip.rst
 RUN apt-get -y install libffi-dev libcairo2 build-essential
 ENV PYTHONPATH="/opt/graphite/lib/:/opt/graphite/webapp/"
-RUN pip install gunicorn flit_core
+RUN pip install gunicorn==23.0.0 flit_core==3.12.0
 RUN pip install --no-binary=:all: https://github.com/graphite-project/whisper/tarball/1.1.10
 RUN pip install --no-binary=:all: https://github.com/graphite-project/carbon/tarball/1.1.10
 RUN pip install --no-binary=:all: https://github.com/graphite-project/graphite-web/tarball/1.1.10

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -109,7 +109,7 @@ http {
     add_header Access-Control-Allow-Methods "GET, OPTIONS";
     add_header Access-Control-Allow-Headers "origin, authorization, accept";
 
-    location /content {
+    location /static {
       alias /opt/graphite/webapp/content;
     }
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -10,7 +10,7 @@ autorestart = true
 
 [program:carbon-cache]
 ;user = www-data
-command = /opt/graphite/bin/carbon-cache.py --pidfile /var/run/carbon-cache-a.pid --debug start
+command = python3 /opt/graphite/bin/carbon-cache.py --pidfile /var/run/carbon-cache-a.pid --debug start
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true
@@ -26,14 +26,14 @@ autorestart = true
 ;user = www-data
 directory = /opt/graphite/webapp
 environment = PYTHONPATH='/opt/graphite/webapp'
-command = gunicorn3 -b127.0.0.1:8000 -w2 graphite.wsgi
+command = gunicorn wsgi --pythonpath=/opt/graphite/webapp/graphite --bind 127.0.0.1:8000
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true
 
 [program:statsd]
 ;user = www-data
-command = node /node_modules/statsd/stats.js /src/statsd/config.js
+command = node /usr/local/lib/node_modules/statsd/stats.js /src/statsd/config.js
 stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stderr_logfile = /var/log/supervisor/%(program_name)s.log
 autorestart = true


### PR DESCRIPTION
Bump Grafana 8.1.3 -> 11.6.0
Bump Graphite 1.1.8 -> 1.1.10
Change base docker image to Python 3.9 on Debian 12.
Change statsd to an npm global install.
Update supervisord & nginx config to match the new setup of graphite / statsd.
Minor Dockerfile improvements.
Fixes https://github.com/dokku/docker-grafana-graphite/issues/7 and probably https://github.com/dokku/dokku-graphite/issues/28.

I've put an updated image with these changes at [tombarone/docker-grafana-graphite](https://hub.docker.com/r/tombarone/docker-grafana-graphite) and have deployed it on a few servers with no problems so far.
Will push fixes here if I come across any issues.

Thanks for all the work behind dokku!